### PR TITLE
add $MINTPY_HOME/mintpy to $PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
 # Dockerized ARIA-tools + Mintpy
+
 * if you want to build your images locally, follow step 1b
 * if you want to pull from my personal dockerhub, follow step 1a
 
-## 1a. Running the `mintpy` and `ARIA-tools` containers
+## 1a. Pull the `mintpy` and `ARIA-tools` containers from DockerHub
+
 ```
-# pulling from Dockerhub
 docker-compose -f docker-compose-PullFromDockerHub.yml up -d
 ```
 
-## 1b. building the images locally (without Dockerhub)
-Run these commands:
-```
-# starting
-docker-compose -f docker-compose-BuildLocally.yml up -d
+## 1b. Build the images locally (without Dockerhub)
 
-# shutting down
+Run the command below to start (create if not exist) the container. Add `--build` suffix to re-build the existing container.
+
+```
+docker-compose -f docker-compose-BuildLocally.yml up -d
+```
+
+Run the command below to shut down the container:
+
+```
 docker-compose -f docker-compose-BuildLocally.yml down
 ```
 
 ## 2. Entering the containers
-`docker ps  # displays the list of running containers`
+
+Display the list of running containers
+
+```
+docker ps
+```
 
 ```
 CONTAINER ID        IMAGE                             COMMAND             CREATED             STATUS              PORTS               NAMES
@@ -27,4 +37,6 @@ CONTAINER ID        IMAGE                             COMMAND             CREATE
 1884fca09d93        dustinklo/aria-tools-jpl:latest   "/bin/bash"         5 minutes ago       Up 5 minutes                            unavco-docker-images_aria-tools_1
 ```
 
-`docker exec -it <CONTAINER ID> bash`
+```
+docker exec -it <CONTAINER ID> bash
+```

--- a/mintpy-docker/Dockerfile
+++ b/mintpy-docker/Dockerfile
@@ -31,13 +31,15 @@ RUN chmod +x /usr/bin/tini
 WORKDIR /root
 
 # git clone mintpy
-RUN git clone https://github.com/insarlab/MintPy.git
-RUN conda env create -f ./MintPy/docs/conda_env.yml
+ENV MINTPY_HOME "/root/MintPy"
+RUN git clone https://github.com/insarlab/MintPy.git ${MINTPY_HOME}
+RUN conda env create -f ${MINTPY_HOME}/docs/conda_env.yml
 RUN conda clean --all --yes
 
 # activating mintpy environment
 RUN echo "conda activate mintpy" >> /root/.bashrc
-ENV PYTHONPATH "${PYTHONPATH}:/root/MintPy"
+ENV PYTHONPATH ${PYTHONPATH}:${MINTPY_HOME}
+ENV PATH ${PATH}:${MINTPY_HOME}/mintpy
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
This PR 

+ define $MINTPY_HOME so that no work directory is required, although I did not remove WORKDIR command

+ add $MINTPY_HOME/mintpy to $PATH so that mintpy scripts are executable in command line.

+ add a note to README.md to re-build the local image.